### PR TITLE
Synchronized stdout

### DIFF
--- a/bin/apnmachined
+++ b/bin/apnmachined
@@ -40,6 +40,8 @@ opts = GetoptLong.new(
   ["--help", "-h", GetoptLong::NO_ARGUMENT]
 )
 
+$stdout.sync = true
+
 redis_host = '127.0.0.1'
 redis_port = 6379
 apn_host = 'gateway.push.apple.com'

--- a/bin/apnmachined
+++ b/bin/apnmachined
@@ -40,8 +40,6 @@ opts = GetoptLong.new(
   ["--help", "-h", GetoptLong::NO_ARGUMENT]
 )
 
-$stdout.sync = true
-
 redis_host = '127.0.0.1'
 redis_port = 6379
 apn_host = 'gateway.push.apple.com'
@@ -50,6 +48,8 @@ pem = nil
 pem_passphrase = nil
 daemon = false
 log = STDOUT
+
+$stdout.sync = true
 
 opts.each do |opt, arg|
   case opt


### PR DESCRIPTION
Enabled synchronized stdout so that apnmachined output shows up when using foreman (https://github.com/ddollar/foreman/wiki/Missing-Output).
